### PR TITLE
Add prefix to ASCII controls

### DIFF
--- a/ASCII_CONTROL.h
+++ b/ASCII_CONTROL.h
@@ -7,39 +7,39 @@
 //     URL: https://github.com/RobTillaart/RS485
 
 
-#define NUL     0x00    //  NULL char
-#define SOH     0x01    //  Start Of Header
-#define STX     0x02    //  Start of Text
-#define ETX     0x03    //  End of Text
-#define EOT     0x04    //  End of Transmission
-#define ENQ     0x05    //  ENQuiry
-#define ACK     0x06    //  ACKnowledge
-#define BEL     0x07    //  Bell
-#define BS      0x08    //  Back Space
-#define TAB     0x09    //  TAB char
-#define LF      0x0A    //  Line Feed
-#define VT      0x0B    //  Vertical TAB
-#define FF      0x0C    //  Form Feed
-#define CR      0x0D    //  Carriage Return
-#define SO      0x0E    //  Shift Out
-#define SI      0x0F    //  Shift In
-#define DLE     0x10    //  Data Link Escape
-#define DC1     0x11    //  Device Control 1
-#define DC2     0x12    //  Device Control 2
-#define DC3     0x13    //  Device Control 3
-#define DC4     0x14    //  Device Control 4
-#define NAK     0x15    //  NOT ACKnowledge
-#define SYN     0x16    //  Synchronous idle
-#define ETB     0x17    //  End of transmission block
-#define CAN     0x18    //  CANcel 
-#define EM      0x19    //  End of Medium
-#define SUB     0x1A    //  Substitute
-#define ESC     0x1B    //  Escape
-#define FS      0x1C    //  File Separator
-#define GS      0x1D    //  Group Separator
-#define RS      0x1E    //  Record Separator
-#define US      0x1F    //  Unit Separator
-#define DEL     0x7F    //  DELete
+#define ASCII_NUL     0x00    //  ASCII_NULL char
+#define ASCII_SOH     0x01    //  Start Of Header
+#define ASCII_STX     0x02    //  Start of Text
+#define ASCII_ETX     0x03    //  End of Text
+#define ASCII_EOT     0x04    //  End of Transmission
+#define ASCII_ENQ     0x05    //  ASCII_ENQuiry
+#define ASCII_ACK     0x06    //  ASCII_ACKnowledge
+#define ASCII_BEL     0x07    //  Bell
+#define ASCII_BS      0x08    //  Back Space
+#define ASCII_TAB     0x09    //  ASCII_TAB char
+#define ASCII_LF      0x0A    //  Line Feed
+#define ASCII_VT      0x0B    //  Vertical ASCII_TAB
+#define ASCII_FF      0x0C    //  Form Feed
+#define ASCII_CR      0x0D    //  Carriage Return
+#define ASCII_SO      0x0E    //  Shift Out
+#define ASCII_SI      0x0F    //  Shift In
+#define ASCII_DLE     0x10    //  Data Link Escape
+#define ASCII_DC1     0x11    //  Device Control 1
+#define ASCII_DC2     0x12    //  Device Control 2
+#define ASCII_DC3     0x13    //  Device Control 3
+#define ASCII_DC4     0x14    //  Device Control 4
+#define ASCII_NAK     0x15    //  NOT ASCII_ACKnowledge
+#define ASCII_SYN     0x16    //  Synchronous idle
+#define ASCII_ETB     0x17    //  End of transmission block
+#define ASCII_CAN     0x18    //  ASCII_CANcel
+#define ASCII_EM      0x19    //  End of Medium
+#define ASCII_SUB     0x1A    //  Substitute
+#define ASCII_ESC     0x1B    //  Escape
+#define ASCII_FS      0x1C    //  File Separator
+#define ASCII_GS      0x1D    //  Group Separator
+#define ASCII_RS      0x1E    //  Record Separator
+#define ASCII_US      0x1F    //  Unit Separator
+#define ASCII_DEL     0x7F    //  ASCII_DELete
 
 
 //  -- END OF FILE --

--- a/RS485.cpp
+++ b/RS485.cpp
@@ -124,29 +124,29 @@ size_t RS485::write(uint8_t * array, uint8_t length)
 //
 //  commando   value  meaning
 //
-//    SOH      0x01   start of header
-//    STX      0x02   start of text
-//    ETX      0x03   end of text
-//    EOT      0x04   end of transmission
+//    ASCII_SOH      0x01   start of header
+//    ASCII_STX      0x02   start of text
+//    ASCII_ETX      0x03   end of text
+//    ASCII_EOT      0x04   end of transmission
 //
 //  optional
-//    ACK      0x06   ACKnowledge
-//    NAK      0x15   Not Acknowledge
-//    CAN      0x18   CANcel
+//    ASCII_ACK      0x06   ASCII_ACKnowledge
+//    ASCII_NAK      0x15   Not Acknowledge
+//    ASCII_CAN      0x18   ASCII_CANcel
 //
 ///////////////////////////////////////////////////////
 //
 //  A message has the following layout
 //
-//     SOH          start of header
+//     ASCII_SOH          start of header
 //     deviceID     to
 //     deviceID     sender
 //     length       length of message
-//        STX          start of text
+//        ASCII_STX          start of text
 //        message      idem
 //        CHECKSUM     idem, message only!
-//        ETX          end of text
-//     EOT          end of transmission
+//        ASCII_ETX          end of text
+//     ASCII_EOT          end of transmission
 //
 
 size_t RS485::send(uint8_t receiverID, uint8_t msg[], uint8_t len)
@@ -155,19 +155,19 @@ size_t RS485::send(uint8_t receiverID, uint8_t msg[], uint8_t len)
   uint8_t CHKSUM = 0;
 
   setTXmode();                 //  transmit mode
-  _stream->write(SOH);
+  _stream->write(ASCII_SOH);
   n += _stream->write(receiverID);  //  TO
   n += _stream->write(_deviceID);   //  FROM
   n += _stream->write(len);         //  LENGTH BODY
-  n += _stream->write(STX);
+  n += _stream->write(ASCII_STX);
   for (int i = 0; i < len; i++)
   {
     n += _stream->write(msg[i]);
     CHKSUM ^= msg[i];          //  Simple XOR checksum.
   }
   n += _stream->write(CHKSUM);
-  n += _stream->write(ETX);
-  n += _stream->write(EOT);
+  n += _stream->write(ASCII_ETX);
+  n += _stream->write(ASCII_EOT);
   _stream->flush();
   setRXmode();                 //  receive mode
 
@@ -196,7 +196,7 @@ bool RS485::receive(uint8_t &senderID, uint8_t msg[], uint8_t &msglen)
   {
     //  waiting for new packet
     case 0:
-      if (v == SOH)
+      if (v == ASCII_SOH)
       {
         _bidx = 0;        //  start new packet
         CHKSUM = 0;
@@ -224,9 +224,9 @@ bool RS485::receive(uint8_t &senderID, uint8_t msg[], uint8_t &msglen)
       state = 4;
       break;
 
-    //  expect STX
+    //  expect ASCII_STX
     case 4:
-      if (v == STX) state = 5;
+      if (v == ASCII_STX) state = 5;
       else state = 99;
       break;
 
@@ -252,15 +252,15 @@ bool RS485::receive(uint8_t &senderID, uint8_t msg[], uint8_t &msglen)
       length--;
       break;
 
-    //  expect ETX
+    //  expect ASCII_ETX
     case 6:
-      if (v == ETX) state = 7;
+      if (v == ASCII_ETX) state = 7;
       else state = 99;
       break;
 
-    //  expect EOT
+    //  expect ASCII_EOT
     case 7:
-      if (v == EOT)
+      if (v == ASCII_EOT)
       {
         msglen = _bidx;
         for (int i = 0; i < msglen; i++)
@@ -274,8 +274,8 @@ bool RS485::receive(uint8_t &senderID, uint8_t msg[], uint8_t &msglen)
       break;
 
     //  SKIP until next packet
-    case 99:  //  wait for EOT in case of error
-      if (v == EOT) state = 0;
+    case 99:  //  wait for ASCII_EOT in case of error
+      if (v == ASCII_EOT) state = 0;
       break;
   }
 

--- a/examples/RS485_master_ACK_NACK/RS485_master_ACK_NACK.ino
+++ b/examples/RS485_master_ACK_NACK/RS485_master_ACK_NACK.ino
@@ -49,10 +49,10 @@ void loop()
     uint8_t answer = rs485.read();
     switch (answer)
     {
-      case ACK:
+      case ASCII_ACK:
         Serial.println(" ACK");
         break;
-      case NAK:
+      case ASCII_NAK:
         Serial.println(" NAK");
         break;
       default:

--- a/examples/RS485_slave_ACK_NACK/RS485_slave_ACK_NACK.ino
+++ b/examples/RS485_slave_ACK_NACK/RS485_slave_ACK_NACK.ino
@@ -43,11 +43,11 @@ void loop()
 
     if (isPrintable(c))
     {
-      rs485.write(ACK);
+      rs485.write(ASCII_ACK);
     }
     else
     {
-      rs485.write(NAK);
+      rs485.write(ASCII_NAK);
     }
 
   }


### PR DESCRIPTION
Without the prefix, the FS control clashes with some defines from LittleFS (and I assume SPIFFS as well).